### PR TITLE
ignore null properties

### DIFF
--- a/src/main/resources/FoghornRestServer/model-cc.mustache
+++ b/src/main/resources/FoghornRestServer/model-cc.mustache
@@ -178,10 +178,12 @@ void {{classname}}::mergeFrom(const Json& j) {
         }
         {{/isRef}}
         {{^isRef}}
-        if (json.get_kind() != Json::{{jsonType}}) {
-           throw std::runtime_error("{{classname}} property {{name}} was not {{jsonType}}");
+        if (json.get_kind() != Json::null ) {
+           if (json.get_kind() != Json::null && json.get_kind() != Json::{{jsonType}}) {
+             throw std::runtime_error("{{classname}} property {{name}} was not {{jsonType}}");
+           }
+            {{name}} = json.as<Json::{{jsonType}}_t>();
         }
-        {{name}} = json.as<Json::{{jsonType}}_t>();
         {{/isRef}}
         {{/isJson}}
 	{{/isContainer}}


### PR DESCRIPTION
json to AnalyticNew was failing when id was set to null, for example,

{"id": null, "source": "select * from a"}

was throwing a "id is not a string" error. Null properties should just be ignored. Some clients choose to serialize null values while others omit them, we should support either strategy.